### PR TITLE
Improve-bundle-size and improve dx

### DIFF
--- a/src/lib/componentRegistry.ts
+++ b/src/lib/componentRegistry.ts
@@ -20,7 +20,7 @@ class ComponentRegistry {
 	#getFileImports = () => {
 		return import.meta.glob<OUIComponent>(
 			['$lib/components/**/*.svelte', '!$lib/components/ui/**/*.svelte'],
-			{ eager: true, import: 'default' }
+			{ eager: false, import: 'default' }
 		);
 	};
 


### PR DESCRIPTION
This  introduces a new plugin to optimize Hot Module Replacement (HMR) for  "async-component-loader.svelte" component . The plugin ensures that only components from the specified directory are handled, improving the development experience. Additionally, it includes a warning suppression for dynamically imported core components during the build process.