### PR TITLE
fix cta urls

### DIFF
--- a/src/lib/demo/cta.svelte
+++ b/src/lib/demo/cta.svelte
@@ -23,7 +23,7 @@
 				<div class="mt-8 flex flex-wrap items-center justify-center gap-4">
 					<Button
 						variant="secondary"
-						href="https://github.com/max-got/originui-svelte/discussions"
+						href="https://originui.com/"
 						target="_blank"
 						rel="noopener noreferrer"
 						aria-label="Send a suggestion to the Origin UI - Svelte repository"
@@ -31,7 +31,7 @@
 						Visit Original
 					</Button>
 					<Button
-						href="https://originui.com/"
+						href="https://github.com/max-got/originui-svelte/discussions"
 						target="_blank"
 						rel="noopener noreferrer"
 						aria-label="Visit the original Origin UI website"


### PR DESCRIPTION
## Description

The urls for the cta buttons were swapped. This PR fixes them

![image](https://github.com/user-attachments/assets/3fdc1dc5-e488-4ed0-9589-bb419cada947)

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] New component(s)
- [ ] Enhancement to existing component
- [x] Bug fix
- [ ] Documentation
- [ ] Other:

## Component Details

<!-- Only fill this section if you're adding/modifying components -->

**Category:** <!-- e.g., inputs, buttons -->
**Component Name(s):** <!-- e.g., input-58.svelte -->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] Matches original design (or improves it)
- [ ] Uses Svelte 5 runes
- [ ] Follows project structure
- [ ] Ran `pnpm generate:registry`
- [ ] Added route config (if new category)
- [ ] Added dependencies to `constants.ts` (if needed)
- [ ] Added placeholder content (if .todo/.soon)
- [ ] Tested in light/dark mode
- [ ] Checked accessibility

## Screenshots

<!-- Add before/after screenshots if applicable -->

## Related Issues

<!-- Link related issues using #issue-number -->

---

> [!TIP]
> Need help? Check our [Contributing Guide](../README.md#contributing) or open a Draft PR for early feedback!
